### PR TITLE
Simplify state classes

### DIFF
--- a/client.py
+++ b/client.py
@@ -90,7 +90,7 @@ def play_as_captain(network, screen):
     game_states = "play"
 
     try:
-        str_board, can_act, is_stopped = network.send("captain get")
+        can_act, is_stopped, str_board = network.send("captain get")
     except Exception as e:
         print(e)
 
@@ -102,7 +102,7 @@ def play_as_captain(network, screen):
         got = network.listen(blocking=False)
         if got:
             if got == "sending game state":
-                str_board, can_act, is_stopped = network.listen()
+                can_act, is_stopped, str_board = network.listen()
 
         # collect pygame events
         clicked_locations = set()
@@ -118,10 +118,10 @@ def play_as_captain(network, screen):
         if can_act:
             target_clicked = detect_target_clicked(clicked_locations, str_board)
             if target_clicked:
-                str_board, can_act, is_stopped = send_to_server_user_actions(network, "captain clicked loc", target_clicked)
+                can_act, is_stopped, str_board = send_to_server_user_actions(network, "captain clicked loc", target_clicked)
 
         if not is_stopped and is_rect_clicked(stop_button, clicked_locations):
-            str_board, can_act, is_stopped = network.send("captain stop")
+            can_act, is_stopped, str_board = network.send("captain stop")
 
         # draw
         draw_captain_screen(screen, bg_img_data, str_board, is_stopped, stop_button)
@@ -169,7 +169,7 @@ def play_as_first_mate(network, screen):
     game_states = "play"
 
     try:
-        powers_charges, hp, can_act, is_stopped= network.send("first mate get")
+        can_act, is_stopped, powers_charges, hp = network.send("first mate get")
     except Exception as e:
         print(e)
 
@@ -185,7 +185,7 @@ def play_as_first_mate(network, screen):
         got = network.listen(blocking=False)
         if got:
             if got == "sending game state":
-                powers_charges, hp, can_act, is_stopped = network.listen()
+                can_act, is_stopped, powers_charges, hp = network.listen()
 
         # collect pygame events
         clicked_locations = set()
@@ -201,7 +201,7 @@ def play_as_first_mate(network, screen):
         if can_act:
             power_clicked = detect_power_clicked(powers_rects[:len(powers_charges)], clicked_locations)
             if power_clicked:
-                powers_charges, hp, can_act, is_stopped = send_to_server_user_actions(network, "first mate clicked power", powers_rects.index(power_clicked))
+                can_act, is_stopped, powers_charges, hp = send_to_server_user_actions(network, "first mate clicked power", powers_rects.index(power_clicked))
                 # power clicked is sent to the server as the index of the power in powerActionsList witch is the same as powers_rects
 
         # draw
@@ -250,7 +250,7 @@ def play_as_engineer(network, screen):
     game_states = "play"
 
     try:
-        tools_state, can_act, is_stopped = network.send("engineer get")
+        can_act, is_stopped, tools_state = network.send("engineer get")
     except Exception as e:
         print(e)
 
@@ -267,7 +267,7 @@ def play_as_engineer(network, screen):
         got = network.listen(blocking=False)
         if got:
             if got == "sending game state":
-                tools_state, can_act, is_stopped = network.listen()
+                can_act, is_stopped, tools_state = network.listen()
 
         # collect pygame events
         clicked_locations = set()
@@ -288,7 +288,7 @@ def play_as_engineer(network, screen):
             tool_clicked = detect_power_clicked(possible_tools_to_break_rects, clicked_locations)
             if tool_clicked:
                 tool_clicked_cords = [(i, colour.index(tool_clicked)) for i, colour in enumerate(tools_rects) if tool_clicked in colour][0]
-                tools_state, can_act, is_stopped = send_to_server_user_actions(network, "engineer clicked tool", tool_clicked_cords)
+                can_act, is_stopped, tools_state = send_to_server_user_actions(network, "engineer clicked tool", tool_clicked_cords)
 
         # draw
         draw_engineer_screen(screen, bg_img_data, is_stopped, tools_state, tools_rects)

--- a/player.py
+++ b/player.py
@@ -120,14 +120,14 @@ class State:
     def __eq__(self, other):
         return tuple(self) == tuple(other)
 
+    def __iter__(self):
+        yield from self.__dict__.values()
+
 
 class CaptainState(State):
     def __init__(self, player, game):
         super().__init__(player, game)
         self.board_str = player.get_board_str(game)
-
-    def __iter__(self):
-        yield from (self.board_str, self.can_act, self.is_game_stopped)
 
 
 class FirstMateState(State):
@@ -136,24 +136,15 @@ class FirstMateState(State):
         self.powers_charges = player.get_powers_charges()
         self.hp = player.submarine.hp
 
-    def __iter__(self):
-        yield from (self.powers_charges, self.hp, self.can_act, self.is_game_stopped)
-
 
 class EngineerState(State):
     def __init__(self, player, game):
         super().__init__(player, game)
         self.tools_state = player.get_tools_state()
     
-    def __iter__(self):
-        yield from (self.tools_state, self.can_act, self.is_game_stopped)
-
 
 class RadioOperatorState(State):
     def __init__(self, player, game):
         super().__init__(player, game)
         enemy_submarine = player.submarine.get_enemy_submarine(game)
         self.last_enemy_move_direction = f"{len(enemy_submarine.path)}. " + enemy_submarine.last_move_direction
-
-    def __iter__(self):
-        yield from (self.last_enemy_move_direction, self.is_game_stopped)

--- a/player.py
+++ b/player.py
@@ -105,6 +105,9 @@ class RadioOperatorPlayer(Player):
         super().__init__(team, role, submarine)
         self.submarine.engineer = self
 
+    def is_can_act(self):
+        return True
+
     def get_state(self, game):
         return RadioOperatorState(self, game)
 

--- a/player.py
+++ b/player.py
@@ -114,14 +114,14 @@ class State:
         self.can_act = player.is_can_act()
         self.is_game_stopped = game.is_stopped
 
+    def __eq__(self, other):
+        return tuple(self) == tuple(other)
+
 
 class CaptainState(State):
     def __init__(self, player, game):
         super().__init__(player, game)
         self.board_str = player.get_board_str(game)
-
-    def __eq__(self, other):
-        return tuple(self) == tuple(other)
 
     def __iter__(self):
         yield from (self.board_str, self.can_act, self.is_game_stopped)
@@ -133,9 +133,6 @@ class FirstMateState(State):
         self.powers_charges = player.get_powers_charges()
         self.hp = player.submarine.hp
 
-    def __eq__(self, other):
-        return tuple(self) == tuple(other)
-
     def __iter__(self):
         yield from (self.powers_charges, self.hp, self.can_act, self.is_game_stopped)
 
@@ -144,11 +141,7 @@ class EngineerState(State):
     def __init__(self, player, game):
         super().__init__(player, game)
         self.tools_state = player.get_tools_state()
-
-
-    def __eq__(self, other):
-        return tuple(self) == tuple(other)
-
+    
     def __iter__(self):
         yield from (self.tools_state, self.can_act, self.is_game_stopped)
 
@@ -159,11 +152,5 @@ class RadioOperatorState(State):
         enemy_submarine = player.submarine.get_enemy_submarine(game)
         self.last_enemy_move_direction = f"{len(enemy_submarine.path)}. " + enemy_submarine.last_move_direction
 
-
-    def __eq__(self, other):
-        return tuple(self) == tuple(other)
-
     def __iter__(self):
         yield from (self.last_enemy_move_direction, self.is_game_stopped)
-
-

--- a/player.py
+++ b/player.py
@@ -148,3 +148,6 @@ class RadioOperatorState(State):
         super().__init__(player, game)
         enemy_submarine = player.submarine.get_enemy_submarine(game)
         self.last_enemy_move_direction = f"{len(enemy_submarine.path)}. " + enemy_submarine.last_move_direction
+
+    def __iter__(self):
+        yield from (self.last_enemy_move_direction, self.is_game_stopped)


### PR DESCRIPTION
# Make the State classes simpler

* Add `is_can_act` method to `RadioOperatorPlayer` which always return true
* Move all `__eq__` methods to the base class - Can be done immediately as all the methods implemented the same way
* Move all `__iter__` methods to the base class:
  * Can be done if the tuple returned starts from the attributes of the base class and goes to the attributes of the inheriting class in the order of the assignments of the attributes
  * Demands changing the way the tuple is returned and accepted in both server & client ends
  * I checked that changing the tuple order works on `Captain` but not on the 3 other roles
  * **It should be checked that changing the order of the tuple does not break the 3 other roles**